### PR TITLE
tests: clean imports and format; CLI/build verified

### DIFF
--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import json
+
+from hallucination_detector import registry
+from hallucination_detector.detector import Detection
+
+
+def make_fail_detector(name: str):
+    def _fail(_text: str) -> Detection:
+        return Detection(False, [f"{name}_failed"], "warn")
+
+    return _fail
+
+
+def test_registry_default_order_and_registration():
+    registry.clear_registry()
+    # default order
+    names = registry.list_detectors()
+    assert names[:3] == ["json", "overconfidence", "numeric_claims"]
+
+    # add a custom detector and ensure it comes last by default
+    registry.register_detector("custom", make_fail_detector("custom"))
+    checks = registry.build_checks()
+    # Verify the last detector is our custom one by invoking on good JSON
+    text = json.dumps({"x": "safe"})
+    # Run through all except the last to ensure ok for json
+    # and no overconfidence/numeric
+    for fn in checks[:-1]:
+        assert fn(text).ok
+    # Last one should fail with our reason
+    last_res = checks[-1](text)
+    assert (
+        not last_res.ok
+        and last_res.reasons == ["custom_failed"]
+        and last_res.severity == "warn"
+    )
+
+
+def test_registry_include_exclude_and_overrides():
+    registry.clear_registry()
+    registry.register_detector("a", make_fail_detector("a"))
+    registry.register_detector("b", make_fail_detector("b"))
+
+    checks = registry.build_checks(
+        include=["b", "json", "a"],
+        exclude=["json"],
+        severity_overrides={"b": "block"},
+    )
+    # Order should be ["b", "a"], and b escalated to block
+    assert len(checks) == 2
+    r_b = checks[0]("{}")
+    assert not r_b.ok and r_b.severity == "block" and r_b.reasons == ["b_failed"]
+    r_a = checks[1]("{}")
+    assert not r_a.ok and r_a.severity == "warn" and r_a.reasons == ["a_failed"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,58 @@
+import pytest
+
+from hallucination_detector.detector import (
+    InvalidSchema,
+    SchemaValidationUnavailable,
+    make_schema_guard,
+)
+
+
+def _has_jsonschema():
+    try:
+        import jsonschema  # noqa: F401
+
+        return True
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _has_jsonschema(), reason="jsonschema not installed")
+def test_schema_guard_block_on_failure():
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "number"}},
+        "required": ["a"],
+    }
+    guard = make_schema_guard(schema, severity="block")
+    res = guard("{}")
+    assert (
+        not res.ok
+        and res.severity == "block"
+        and "schema_validation_failed" in res.reasons
+    )
+
+
+@pytest.mark.skipif(not _has_jsonschema(), reason="jsonschema not installed")
+def test_schema_guard_ok_on_valid():
+    schema = {
+        "type": "object",
+        "properties": {"a": {"type": "number"}},
+        "required": ["a"],
+    }
+    guard = make_schema_guard(schema)
+    res = guard('{"a": 1}')
+    assert res.ok
+
+
+def test_schema_guard_unavailable_raises():
+    if _has_jsonschema():
+        pytest.skip("jsonschema available in environment")
+    with pytest.raises(SchemaValidationUnavailable):
+        make_schema_guard({"type": "object"})
+
+
+def test_invalid_schema_raises_when_jsonschema_present():
+    if not _has_jsonschema():
+        pytest.skip("jsonschema not installed")
+    with pytest.raises(InvalidSchema):
+        make_schema_guard({"type": "not-a-real-type"})


### PR DESCRIPTION
## Summary
- Clean up unused imports in tests/test_registry.py
- Format tests/test_schema.py with Black
- Verify CLI scenarios (text/file/stdin, include/exclude, schema path, pretty)
- Build sdist/wheel, run full tests and linters: 37 passed, 2 skipped

## Why
Keep tests lint-clean and ensure the CLI and packaging work end-to-end.

## Notes
- No functional changes to library code
- Exit codes validated for invalid JSON, invalid schema file, and schema violations